### PR TITLE
Adding ProtectiveClothing and FirstAid prompts and adding sequential prompting

### DIFF
--- a/app/PromptInputs.py
+++ b/app/PromptInputs.py
@@ -80,7 +80,7 @@ class Activity(PromptInput):
         Use the following output format:
         Description: <your description>
         Comparison: <your comparison>
-        Answer: <your answer>'''
+        Overall Answer: <your answer>'''
     
     def get_shortform_feedback(self):
         return ShortformFeedback(positive_feedback=f"Correct! '{self.activity}' is an activity.",
@@ -124,7 +124,7 @@ class HowItHarmsInContext(PromptInput):
         Description: It is argued that wet hands during a fluids laboratory can cause harm through electrocution.
         Explanation: As water is a conductor of electricity, touching electronics with wet hands can cause electrocution as
         the water provides a path for electrical current to flow through the body.
-        Answer: True
+        Overall Answer: True
         '''
 
         example_of_incorrect_how_it_harms = f'''
@@ -139,7 +139,7 @@ class HowItHarmsInContext(PromptInput):
         Description: It is argued that an ink spillage during a fluids laboratory can cause radiation exposure.
         Explanation: Radiation exposure is not a way that ink spillage during the fluids laboratory causes harm, 
         as the hazard primarily involves physical contamination rather than radiation.
-        Answer: False.
+        Overall Answer: False.
         '''
         return f'''
         {example_of_correct_how_it_harms}
@@ -151,7 +151,7 @@ class HowItHarmsInContext(PromptInput):
         Use the following output format:
         Description: <your description>
         Explanation: <your Explanation>
-        Answer: <your answer>'''
+        Overall Answer: <your answer>'''
     
     def get_shortform_feedback(self):
         return ShortformFeedback(positive_feedback=f"Correct! '{self.how_it_harms}' is a way that the hazard: '{self.hazard}' causes harm.",
@@ -182,7 +182,7 @@ class WhoItHarmsInContext(PromptInput):
         Output:
         Description: "Mucking out a stable" involves the process of cleaning and removing waste, such as manure and soiled bedding, from a horse's stall or stable.
         Explanation: It is highly likely that a "Stable hand" would take part in this activity as it is a core responsibility associated with their role in maintaining the stable environment.
-        Answer: True
+        Overall Answer: True
         '''
 
         example_of_incorrect_who_it_harms = f'''
@@ -194,7 +194,7 @@ class WhoItHarmsInContext(PromptInput):
         Output:
         Description: A "Fluids laboratory" is a facility where controlled experiments and analyses are conducted to study the properties and behaviors of various fluids, including liquids and gases.
         Explanation: It is highly unlikely that a "Stable hand" would take part in this activity, as their expertise typically lies in the care and maintenance of horses within a stable environment rather than laboratory work with fluids.
-        Answer: False
+        Overall Answer: False
         '''
         return f'''
         {example_of_correct_who_it_harms}
@@ -209,7 +209,7 @@ class WhoItHarmsInContext(PromptInput):
         Your answer should be in the format:
         Description: <your description>
         Explanation: your_explanation
-        Answer: <your answer>'''
+        Overall Answer: <your answer>'''
     
     def get_shortform_feedback(self):
         return ShortformFeedback(positive_feedback=f"Correct! '{self.who_it_harms}' could take part in the activity: '{self.activity}'.",
@@ -236,33 +236,32 @@ class ProtectiveClothing(PromptInput):
     
     def generate_prompt_without_few_shot_examples(self):
         return f'''Follow these instructions:
-        Follow these instructions:
-        1. In one sentence, describe the hazard: "{self.hazard}" during the
+        1. Description: In one sentence, describe the hazard: "{self.hazard}" during the
         activity: "{self.activity}" given how the hazard harms: "{self.how_it_harms}"
         and who the hazard harms: "{self.who_it_harms}".
-        2. If "{self.control_measure}" is an example of providing protective clothing, answer True, else answer False.
-        3. Explain whether "{self.control_measure}" reduces the harm caused by the hazard.
-        4. If "{self.control_measure}" reduces the harm caused by the hazard, answer True, else answer False.
-        5. If both previous answers are True, answer True, else answer False.'''
+        2. Protective Clothing Answer: If "{self.control_measure}" is an example of providing protective clothing, answer True, else answer False.
+        3. Reduces Harm Explanation: Explain whether "{self.control_measure}" reduces the harm caused by the hazard.
+        4. Reduces Harm Answer: If "{self.control_measure}" reduces the harm caused by the hazard, answer True, else answer False.
+        5. If both "Protective Clothing Answer" and "Reduces Harm Answer" are True, answer True. Else answer False.'''
     
     def generate_prompt(self):
         example_of_correct_protective_clothing = '''
         Example Input:
         Follow these instructions:
-        1. In one sentence, describe the hazard: "Syringes with sharp needles" during the
+        1. Description: In one sentence, describe the hazard: "Syringes with sharp needles" during the
         activity: "Fluids laboratory" given how the hazard harms: "Sharp needles can pierce the skin and cause bleeding"
         and who the hazard harms: "Students".
-        2. If "Wearing lab coat and PPE" is an example of providing protective clothing, answer True, else answer False.
-        3. Explain whether "Wearing lab coat and PPE" reduces the harm caused by the hazard.
-        4. If "Wearing lab coat and PPE" reduces the harm caused by the hazard, answer True, else answer False.
-        5. If both previous answers are True, answer True, else answer False.
+        2. Protective Clothing Answer: If "Wearing lab coat and PPE" is an example of providing protective clothing, answer True, else answer False.
+        3. Reduces Harm Explanation: Explain whether "Wearing lab coat and PPE" reduces the harm caused by the hazard.
+        4. Reduces Harm Answer: If "Wearing lab coat and PPE" reduces the harm caused by the hazard, answer True, else answer False.
+        5. If both "Protective Clothing Answer" and "Reduces Harm Answer" are True, answer True. Else answer False.
 
         Output:
         Description: The hazard of "Syringes with sharp needles" during the activity "Fluids laboratory" can lead to sharp needles piercing the skin and causing bleeding to students.
         Protective Clothing Answer: True.
         Reduces Harm Explanation: "Wearing lab coat and PPE" provides a protective barrier between the needle and skin, thus reducing the harm caused by the hazard.
         Reduces Harm Answer: True. 
-        Overall Answer: True.
+        Since "Protective Clothing Answer: True" and "Reduces Harm Answer: True", Overall Answer: True.
         '''
 
         return f'''
@@ -277,6 +276,14 @@ class ProtectiveClothing(PromptInput):
         Reduces Harm Explanation: <your explanation>
         Reduces Harm Answer: <your answer>
         Overall Answer: <your answer>'''
+    
+    def get_shortform_feedback(self):
+        # Feedback is only given when a mitigation is written in prevention input.
+        return ShortformFeedback(positive_feedback=f"Correct! '{self.control_measure}' is an example of a mitigation measure",
+                                 negative_feedback=f"Incorrect. '{self.control_measure}' is not a prevention measure, but is actually a mitigation measure.")
+    
+    def get_longform_feedback(self):
+        return f"{self.control_measure} is an example of wearing protective clothing, which reduces the harm caused by the hazard event so is therefore a mitigation measure."
     
 class FirstAid(PromptInput):
     def __init__(self, activity, hazard, who_it_harms, how_it_harms, control_measure):
@@ -294,32 +301,33 @@ class FirstAid(PromptInput):
     def generate_prompt_without_few_shot_examples(self):
         return f'''Follow these instructions:
         Follow these instructions:
-        1. In one sentence, describe the hazard: "{self.hazard}" during the
-        activity: "{self.activity}" given how the hazard harms: "{self.how_it_harms}"
-        and who the hazard harms: "{self.who_it_harms}".
-        2. First aid is the initial treatment or assistance given to someone who has been harmed. If "{self.control_measure}" is an example of providing first aid for the hazard: "{self.hazard}", answer True, else answer False.
-        3. Explain whether "{self.control_measure}" reduces the harm caused by the hazard after it has occurred.
-        4. If "{self.control_measure}" reduces the harm caused by the hazard after it has occurred, answer True, else answer False.
-        5. If both previous answers are True, answer True, else answer False.'''
+        1. Describe "{self.control_measure}" in one sentence.
+        2. Initial Medical Response Explanation: "Definition of initial medical response": "Immediate actions taken by individuals in the presence of a medical emergency or injury to provide basic care or initiate further assistance as needed.
+        Given this "Definition of initial medical response", explain whether "{self.control_measure}" is an example of initial medical response.
+        3. Initial Medical Response Answer: If "{self.control_measure}" is an example of an example of initial medical response, answer True, else answer False.
+        4. Reduces Harm Explanation: Explain whether "{self.control_measure}" reduces the harm caused by the hazard: "{self.hazard}" given how it harms: "{self.how_it_harms}".
+        5. Reduces Harm Answer: If "{self.control_measure}" reduces the harm, answer True, else answer False.
+        6. If both "First Aid Answer" and "Reduces Harm Answer" are True, answer True, else answer False.'''
     
     def generate_prompt(self):
         example_of_correct_protective_clothing = '''
         Example Input:
         Follow these instructions:
-        1. In one sentence, describe the hazard: "Ink spillage" during the
-        activity: "Fluids laboratory" given how the hazard harms: "Serious eye damage"
-        and who the hazard harms: "Students".
-        2. First aid is the initial treatment or assistance given to someone who has been harmed. If "Washing the eyes out with clean water" is an example of providing first aid for the hazard: "Ink spillage", answer True, else answer False.
-        3. Explain whether "Washing the eyes out with clean water" reduces the harm caused by the hazard after it has occurred.
-        4. If "Washing the eyes out with clean water" reduces the harm caused by the hazard after it has occurred, answer True, else answer False.
-        5. If both previous answers are True, answer True, else answer False.
+        1. Description: Describe "Washing the eyes out with clean water" in one sentence.
+        2. Initial Medical Response Explanation: "Definition of initial medical response": "Immediate actions taken by individuals in the presence of a medical emergency or injury to provide basic care or initiate further assistance as needed.
+        Given this "Definition of initial medical response", explain whether ""Washing the eyes out with clean water"" is an example of initial medical response.
+        3. Initial Medical Response Answer:  If "Washing the eyes out with clean water" is an example of initial medical response, answer True, else answer False.
+        4. Reduces Harm Explanation: Explain whether "Washing the eyes out with clean water" reduces the harm caused by the hazard: "Ink spillage" given how it harms: "Serious eye damage".
+        5. Reduces Harm Answer: If "Washing the eyes out with clean water" reduces the harm, answer True, else answer False.
+        6. If both "First Aid Answer" and "Reduces Harm Answer" are True, answer True, else answer False.
 
         Output:
-        Description: The hazard of "Ink spillage" during the activity "Fluids laboratory" can lead to serious eye damage to students.
-        First Aid Answer: True.
-        Reduces Harm Explanation: "Washing the eyes out with clean water" will help to wash the ink out of the eyes and reduce eye damage after the hazard event has occurred.
+        Description: "Washing the eyes out with clean water" is the process of rinsing the eyes with clean water to remove any foreign bodies or chemicals that may have entered the eye.
+        Intial Medical Response Explanation: "Washing the eyes out with clean water" is an example of basic care provided to an individual so is an example of "initial medical response".
+        Initial Medical Response Answer: True.
+        Reduces Harm Explanation: "Washing the eyes out with clean water" reduces the harm caused by the hazard as it helps to wash the ink out of the eyes and reduce eye damage.
         Reduces Harm Answer: True.
-        Overall Answer: True.
+        Since "First Aid Answer: True" and "Reduces Harm Answer: True", Overall Answer: True.
         '''
 
         return f'''
@@ -330,11 +338,19 @@ class FirstAid(PromptInput):
 
         Use the following output format:
         Description: <your description>
-        Protective Clothing Answer: <your answer>
+        First Aid Answer: <your answer>
         Reduces Harm Explanation: <your explanation>
         Reduces Harm Answer: <your answer>
         Overall Answer: <your answer>'''
-
+    
+    def get_shortform_feedback(self):
+        # Feedback is only given when a mitigation is written in prevention input.
+        return ShortformFeedback(positive_feedback=f"Correct! '{self.control_measure}' is an example of a mitigation measure",
+                                 negative_feedback=f"Incorrect. '{self.control_measure}' is not a prevention measure, but is actually a mitigation measure.")
+    
+    def get_longform_feedback(self):
+        return f"""{self.control_measure} is an example of a first aid measure, which reduces the harm caused by the hazard event after it has occurred; it is therefore a mitigation measure."""
+    
 class Prevention(PromptInput):
     def __init__(self, prevention, activity, hazard, how_it_harms, who_it_harms):
         super().__init__()

--- a/app/RegexPatternMatcher.py
+++ b/app/RegexPatternMatcher.py
@@ -5,7 +5,7 @@ class RegexPatternMatcher:
         pass
     
     def check_string_for_true_or_false(self, string):
-        pattern = re.compile(r"(true|false)", re.IGNORECASE)
+        pattern = re.compile(r"Overall Answer: (true|false)", re.IGNORECASE)
         match = re.search(pattern, string)
         if match:
             return match.group(1).lower() == "true"

--- a/app/RiskAssessment.py
+++ b/app/RiskAssessment.py
@@ -13,6 +13,8 @@ class RiskAssessment:
     def __init__(self, activity, hazard, who_it_harms, how_it_harms,
                   uncontrolled_likelihood, uncontrolled_severity, uncontrolled_risk,
                  prevention, mitigation, controlled_likelihood, controlled_severity, controlled_risk,
+                 prevention_protected_clothing_expected_output, mitigation_protected_clothing_expected_output,
+                 prevention_first_aid_expected_output, mitigation_first_aid_expected_output,
                  prevention_prompt_expected_output, mitigation_prompt_expected_output):
         self.activity = activity
         self.hazard = hazard
@@ -26,6 +28,12 @@ class RiskAssessment:
         self.controlled_likelihood = controlled_likelihood
         self.controlled_severity = controlled_severity
         self.controlled_risk = controlled_risk
+
+        self.prevention_protected_clothing_expected_output = prevention_protected_clothing_expected_output
+        self.mitigation_protected_clothing_expected_output = mitigation_protected_clothing_expected_output
+
+        self.prevention_first_aid_expected_output = prevention_first_aid_expected_output
+        self.mitigation_first_aid_expected_output = mitigation_first_aid_expected_output
 
         self.prevention_prompt_expected_output = prevention_prompt_expected_output
         self.mitigation_prompt_expected_output = mitigation_prompt_expected_output
@@ -198,8 +206,8 @@ class RiskAssessment:
                 self.get_who_it_harms_in_context_input(),
                 # self.get_protective_clothing_input(),
                 # self.get_first_aid_input(),
-                self.get_prevention_input(),
-                self.get_mitigation_input()
+                # self.get_prevention_input(),
+                # self.get_mitigation_input()
                 ]
 
     def get_prompt_output_and_pattern_matched(self, prompt_input_object: Type[PromptInput], LLM_caller: Type[LLMCaller]):

--- a/app/TestModelAccuracy.py
+++ b/app/TestModelAccuracy.py
@@ -24,13 +24,12 @@ class TestModelAccuracy:
         self.sheet_name = sheet_name
         self.test_description = test_description
 
-    def get_prompt_input_and_output(self, input_and_expected_output):
+    def get_prompt_output(self, input_and_expected_output):
         input = input_and_expected_output.input
 
-        prompt_input = self.LLM.get_prompt_input(prompt_input=input)
-        prompt_output = self.LLM.get_model_output(prompt_input=input.generate_prompt())
+        prompt_output = self.LLM.get_model_output(prompt=input.generate_prompt())
         
-        return prompt_input, prompt_output
+        return prompt_output
 
     def convert_list_of_lists_to_string(self, list_of_lists):
         # Convert each sublist to a string with newline
@@ -66,9 +65,8 @@ class TestModelAccuracy:
             for i in range(len(self.list_of_input_and_expected_outputs)):
                 input = self.list_of_input_and_expected_outputs[i].input
 
-                prompt_input, prompt_output = self.get_prompt_input_and_output(self.list_of_input_and_expected_outputs[i])
+                prompt_output = self.get_prompt_output(self.list_of_input_and_expected_outputs[i])
                 
-
                 pattern_matched = pattern_matching_method(prompt_output)
                 expected_output = self.list_of_input_and_expected_outputs[i].expected_output
 
@@ -86,22 +84,9 @@ class TestModelAccuracy:
                 if pattern_matched == expected_output:
                     count_correct += 1
 
-                    # if pattern_matching_method_string == "check_string_for_true_or_false":
-                    #     if pattern_matched == True:
-                    #         count_true_positives += 1
-                    #     else:
-                    #         count_true_negatives += 1
-
                     prompt_outputs_for_correct_responses += f'{i + 1}: {prompt_output}\nExpected output: {expected_output}\n\n'
-                
-                else:
-                    # if pattern_matching_method_string == "check_string_for_true_or_false":
-                    #     if pattern_matched == True:
-                    #         count_false_positives += 1
-                    #     else:  
-                    #         count_false_negatives += 1
-                    
 
+                else:
                     prompt_outputs_for_incorrect_responses += f'{i + 1}: {prompt_output}\nExpected output: {expected_output}\n\n'
                 
                 print(count_correct)
@@ -135,24 +120,10 @@ class TestModelAccuracy:
     
     def get_first_prompt_input_and_output(self):
         first_input = self.list_of_input_and_expected_outputs[0].input
-        first_prompt_input = self.LLM.get_prompt_input(prompt_input=first_input)
-        first_prompt_output = self.LLM.get_model_output(prompt_input=first_input.generate_prompt())
+        first_prompt_input = first_input.generate_prompt()
+        first_prompt_output = self.LLM.get_model_output(prompt=first_prompt_input)
 
         return first_prompt_input, first_prompt_output
-    
-    def total_cost_of_calling_LLM_API(self):
-        GPT_cost_calculator = GPTCostCalculator()
-        
-        if self.LLM_name == 'gpt-3.5-turbo':
-            total_cost_of_calling_LLM_API = 0
-
-            for input_and_expected_output in self.list_of_input_and_expected_outputs:
-                prompt_input, prompt_output = self.get_prompt_input_and_output(input_and_expected_output)
-                total_cost_of_calling_LLM_API = total_cost_of_calling_LLM_API + GPT_cost_calculator.calculate_cost(prompt_input=prompt_input, prompt_output=prompt_output)
-            
-            return total_cost_of_calling_LLM_API
-        else:
-            return 0
     
     def save_test_results(self, 
                           accuracy, 
@@ -171,8 +142,6 @@ class TestModelAccuracy:
             model_parameters = ''
         
         num_examples = len(self.list_of_input_and_expected_outputs)
-
-        # total_cost_of_calling_LLM_API = self.total_cost_of_calling_LLM_API()
 
         new_line_data = [self.test_description, 
                          self.LLM_name, 

--- a/app/example_risk_assessments.py
+++ b/app/example_risk_assessments.py
@@ -22,6 +22,10 @@ RA_empty_input = RiskAssessment(
     controlled_risk="1",
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output='',
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output='',
 )
 
 RA_mitigation_wrong_type = RiskAssessment(
@@ -39,6 +43,10 @@ RA_mitigation_wrong_type = RiskAssessment(
     controlled_risk="1",
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output='',
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output='',
 )
 
 RA_controlled_likelihood_wrong_type = RiskAssessment(
@@ -56,6 +64,10 @@ RA_controlled_likelihood_wrong_type = RiskAssessment(
     controlled_risk="1",
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output='',
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output='',
 )
 
 RA_incorrect_prevention_and_mitigation = RiskAssessment(
@@ -73,6 +85,10 @@ RA_incorrect_prevention_and_mitigation = RiskAssessment(
     controlled_risk="1",
     prevention_prompt_expected_output='neither',
     mitigation_prompt_expected_output='',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output='',
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output='',
 
 )
 
@@ -91,6 +107,10 @@ RA_1 = RiskAssessment(
     controlled_risk="2",
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output='',
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output='',
 )
 
 RA_2_hearing_damage = RiskAssessment(
@@ -108,6 +128,10 @@ RA_2_hearing_damage = RiskAssessment(
     controlled_risk="1",
     prevention_prompt_expected_output='prevention', 
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False
 )
 
 RA_2_mitigation_prevention_switched = RiskAssessment(
@@ -125,6 +149,10 @@ RA_2_mitigation_prevention_switched = RiskAssessment(
     controlled_risk="1",
     prevention_prompt_expected_output='mitigation', 
     mitigation_prompt_expected_output='prevention',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False
 )
 
 
@@ -179,6 +207,10 @@ RA_4 = RiskAssessment(
     controlled_risk="3",
     prevention_prompt_expected_output='mitigation',
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=True,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=True,
 )
 
 RA_4_with_first_aid = RiskAssessment(
@@ -196,6 +228,10 @@ RA_4_with_first_aid = RiskAssessment(
     controlled_risk="3",
     prevention_prompt_expected_output='mitigation',
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=True,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=True,
 )
 
 
@@ -214,6 +250,10 @@ RA_4_with_incorrect_how_it_harms = RiskAssessment(
     controlled_risk="3",
     prevention_prompt_expected_output='mitigation',
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=True,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=True,
 )
 
 RA_5 = RiskAssessment(
@@ -225,12 +265,16 @@ RA_5 = RiskAssessment(
     uncontrolled_severity="3",
     uncontrolled_risk="9",
     prevention="Students should make sure they touch electronics only with dry hands", # reduces likelihood of hazard occurring
-    mitigation="Unplug the pump and call for urgent medical assistance", # reduces severity after hazard has occurred
+    mitigation="Call for urgent medical assistance", # reduces severity after hazard has occurred
     controlled_likelihood="2",
     controlled_severity="3",
     controlled_risk="6",
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=True,
 )
 
 RA_5_mitigation_prevention_switched = RiskAssessment(
@@ -248,6 +292,10 @@ RA_5_mitigation_prevention_switched = RiskAssessment(
     controlled_risk="6",
     prevention_prompt_expected_output='mitigation',
     mitigation_prompt_expected_output='prevention',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=True,
+    mitigation_first_aid_expected_output=False,
 )
 
 RA_6 = RiskAssessment(
@@ -265,6 +313,10 @@ RA_6 = RiskAssessment(
     controlled_risk="2",
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='prevention',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False,
 )
 
 RA_7_water_tank = RiskAssessment(
@@ -283,6 +335,10 @@ RA_7_water_tank = RiskAssessment(
     controlled_risk="4",
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=True,
 )
 
 RA_7_water_tank_mitigation_prevention_switched = RiskAssessment(
@@ -301,6 +357,10 @@ RA_7_water_tank_mitigation_prevention_switched = RiskAssessment(
     controlled_risk="4",
     prevention_prompt_expected_output='mitigation',
     mitigation_prompt_expected_output='prevention',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=True,
+    mitigation_first_aid_expected_output=False,
 )
 
 
@@ -319,6 +379,10 @@ RA_8_syringe_needle = RiskAssessment(
     controlled_risk="2",
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=True,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False,
 )
 
 RA_8_syringe_needle_mitigation_prevention_switched = RiskAssessment(
@@ -336,6 +400,10 @@ RA_8_syringe_needle_mitigation_prevention_switched = RiskAssessment(
     controlled_risk="2",
     prevention_prompt_expected_output='mitigation',
     mitigation_prompt_expected_output='prevention',
+    prevention_protected_clothing_expected_output=True,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False,
 )
 
 # RA_9 = RiskAssessment(
@@ -397,13 +465,17 @@ RA_14 = RiskAssessment(
     uncontrolled_likelihood='4',
     uncontrolled_severity='2',
     uncontrolled_risk='8',
-    prevention='Keep safe distance between the player and audience; Throw the paper plane to a direction without anyone',
+    prevention='Throw the paper plane to a direction without anyone',
     mitigation='',
     controlled_likelihood='1',
     controlled_severity='2',
     controlled_risk='2',
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output='',
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output='',
 )
 
 RA_15 = RiskAssessment(
@@ -421,6 +493,10 @@ RA_15 = RiskAssessment(
     controlled_risk='1',
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=True,
 )
 
 RA_15_mitigation_prevention_switched = RiskAssessment(
@@ -438,6 +514,10 @@ RA_15_mitigation_prevention_switched = RiskAssessment(
     controlled_risk='1',
     prevention_prompt_expected_output='mitigation',
     mitigation_prompt_expected_output='prevention',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=True,
+    mitigation_first_aid_expected_output=False,
 )
 
 RA_17 = RiskAssessment(
@@ -455,6 +535,10 @@ RA_17 = RiskAssessment(
     controlled_risk='1',
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output='',
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output='',
 )
 
 RA_18 = RiskAssessment(
@@ -472,6 +556,10 @@ RA_18 = RiskAssessment(
     controlled_risk='2',
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='prevention', # it is both mitigation and prevention
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False,
 )
 
 RA_19 = RiskAssessment(
@@ -489,6 +577,10 @@ RA_19 = RiskAssessment(
     controlled_risk='2',
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='prevention',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False,
 )
 
 RA_20 = RiskAssessment(
@@ -506,6 +598,10 @@ RA_20 = RiskAssessment(
     controlled_risk='1',
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='prevention', # Another prevention measure as it reduces the likelihood of the zip tie hitting an audience member
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False,
 )
 
 RA_23 = RiskAssessment(
@@ -523,6 +619,10 @@ RA_23 = RiskAssessment(
     controlled_risk='2',
     prevention_prompt_expected_output='prevention',
     mitigation_prompt_expected_output='',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output='',
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output='',
 )
 
 RA_mucking_out_horse = RiskAssessment(
@@ -539,7 +639,11 @@ RA_mucking_out_horse = RiskAssessment(
     controlled_severity='1',
     controlled_risk='1',
     prevention_prompt_expected_output='prevention',
-    mitigation_prompt_expected_output='mitigation'
+    mitigation_prompt_expected_output='mitigation',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=True,
+    prevention_first_aid_expected_output=False,
+    mitigation_first_aid_expected_output=False,
 )
 
 RA_mucking_out_horse_mitigation_prevention_switched = RiskAssessment(
@@ -556,9 +660,12 @@ RA_mucking_out_horse_mitigation_prevention_switched = RiskAssessment(
     controlled_severity='1',
     controlled_risk='1',
     prevention_prompt_expected_output='mitigation',
-    mitigation_prompt_expected_output='prevention'
+    mitigation_prompt_expected_output='prevention',
+    prevention_protected_clothing_expected_output=False,
+    mitigation_protected_clothing_expected_output=False,
+    prevention_first_aid_expected_output=True,
+    mitigation_first_aid_expected_output=False,
 )
-
 
 example_risk_assessments = [
     # Commented out ones which are difficult to classify
@@ -572,11 +679,13 @@ example_risk_assessments = [
     RA_1, RA_2_hearing_damage, 
     RA_4, RA_5, RA_6, RA_7_water_tank,
      RA_14, RA_15, RA_17, RA_18, RA_19, RA_20,
-    RA_23, RA_23,
+    RA_23,
     RA_incorrect_prevention_and_mitigation, RA_2_mitigation_prevention_switched,
         RA_4_with_first_aid,
     RA_5_mitigation_prevention_switched, RA_7_water_tank_mitigation_prevention_switched,
     RA_15_mitigation_prevention_switched,
     RA_mucking_out_horse]
 
-print(len(example_risk_assessments))
+example_risk_assessments_for_protective_clothing_and_first_aid = [
+    RA_1, RA_2_hearing_damage, RA_4, RA_5, RA_6, RA_7_water_tank, RA_14, RA_15, RA_17, RA_18, RA_19, RA_20, RA_23, RA_mucking_out_horse
+]

--- a/app/test_mitigation_first_aid.py
+++ b/app/test_mitigation_first_aid.py
@@ -1,0 +1,22 @@
+from PromptInputs import Prevention
+from ExamplesGenerator import ExamplesGenerator
+from TestModelAccuracy import TestModelAccuracy
+from LLMCaller import OpenAILLM
+from example_risk_assessments import example_risk_assessments_for_protective_clothing_and_first_aid
+
+from ExamplesGenerator import RiskAssessmentExamplesGenerator
+
+if __name__ == '__main__':
+    examples_generator = RiskAssessmentExamplesGenerator(risk_assessments=example_risk_assessments_for_protective_clothing_and_first_aid,
+                                                         ground_truth_parameter='mitigation_first_aid_expected_output',
+                                                        method_to_get_prompt_input='get_mitigation_first_aid_input')
+    
+    examples = examples_generator.get_input_and_expected_output_list()
+
+    test_accuracy = TestModelAccuracy(test_description="""Testing mitigation input in the first aid prompt. Use examples from student Fluids Lab and TPS presentation Risk Assessment examples.
+                                       """,
+                                      LLM=OpenAILLM(),
+                                                LLM_name='gpt-3.5-turbo',
+                                                list_of_input_and_expected_outputs=examples,
+                                                sheet_name='Mitigation First Aid')
+    test_accuracy.run_test()

--- a/app/test_mitigation_protected_clothing.py
+++ b/app/test_mitigation_protected_clothing.py
@@ -1,0 +1,23 @@
+from PromptInputs import Prevention
+from ExamplesGenerator import ExamplesGenerator
+from TestModelAccuracy import TestModelAccuracy
+from LLMCaller import OpenAILLM
+from example_risk_assessments import example_risk_assessments_for_protective_clothing_and_first_aid
+
+from ExamplesGenerator import RiskAssessmentExamplesGenerator
+
+if __name__ == '__main__':
+    examples_generator = RiskAssessmentExamplesGenerator(risk_assessments=example_risk_assessments_for_protective_clothing_and_first_aid,
+                                                         ground_truth_parameter='mitigation_protected_clothing_expected_output',
+                                                        method_to_get_prompt_input='get_mitigation_protective_clothing_input')
+    
+    examples = examples_generator.get_input_and_expected_output_list()
+
+    test_accuracy = TestModelAccuracy(test_description="""Testing mitigation input in the protected clothing prompt. Use examples from student Fluids Lab and TPS presentation Risk Assessment examples.
+                                      
+                                       """,
+                                      LLM=OpenAILLM(),
+                                                LLM_name='gpt-3.5-turbo',
+                                                list_of_input_and_expected_outputs=examples,
+                                                sheet_name='Mitigation Protected Clothing')
+    test_accuracy.run_test()

--- a/app/test_prevention_first_aid.py
+++ b/app/test_prevention_first_aid.py
@@ -1,0 +1,22 @@
+from PromptInputs import Prevention
+from ExamplesGenerator import ExamplesGenerator
+from TestModelAccuracy import TestModelAccuracy
+from LLMCaller import OpenAILLM
+from example_risk_assessments import example_risk_assessments_for_protective_clothing_and_first_aid
+
+from ExamplesGenerator import RiskAssessmentExamplesGenerator
+
+if __name__ == '__main__':
+    examples_generator = RiskAssessmentExamplesGenerator(risk_assessments=example_risk_assessments_for_protective_clothing_and_first_aid,
+                                                         ground_truth_parameter='prevention_first_aid_expected_output',
+                                                        method_to_get_prompt_input='get_prevention_first_aid_input')
+    
+    examples = examples_generator.get_input_and_expected_output_list()
+
+    test_accuracy = TestModelAccuracy(test_description="""Testing prevention input in the first aid prompt. Use examples from student Fluids Lab and TPS presentation Risk Assessment examples.
+                                       """,
+                                      LLM=OpenAILLM(),
+                                                LLM_name='gpt-3.5-turbo',
+                                                list_of_input_and_expected_outputs=examples,
+                                                sheet_name='Prevention First Aid')
+    test_accuracy.run_test()

--- a/app/test_prevention_protected_clothing.py
+++ b/app/test_prevention_protected_clothing.py
@@ -1,0 +1,23 @@
+from PromptInputs import Prevention
+from ExamplesGenerator import ExamplesGenerator
+from TestModelAccuracy import TestModelAccuracy
+from LLMCaller import OpenAILLM
+from example_risk_assessments import example_risk_assessments_for_protective_clothing_and_first_aid
+
+from ExamplesGenerator import RiskAssessmentExamplesGenerator
+
+if __name__ == '__main__':
+    examples_generator = RiskAssessmentExamplesGenerator(risk_assessments=example_risk_assessments_for_protective_clothing_and_first_aid,
+                                                         ground_truth_parameter='prevention_protected_clothing_expected_output',
+                                                        method_to_get_prompt_input='get_prevention_protective_clothing_input')
+    
+    examples = examples_generator.get_input_and_expected_output_list()
+
+    test_accuracy = TestModelAccuracy(test_description="""Testing prevention input in the protected clothing prompt. Use examples from student Fluids Lab and TPS presentation Risk Assessment examples.
+                                      Removed definitions from prompt. Made it more clear that a mitigation reduces severity assuming hazard has led to harm.
+                                       """,
+                                      LLM=OpenAILLM(),
+                                                LLM_name='gpt-3.5-turbo',
+                                                list_of_input_and_expected_outputs=examples,
+                                                sheet_name='Prevention Protected Clothing')
+    test_accuracy.run_test()


### PR DESCRIPTION
1. Added new prompts called FirstAid and ProtectiveClothing which take in a control_measure input which can either be a prevention or a mitigation. The output is either True or False. 2. Added get_prompt_input functions in the Risk Assessment class where the prevention and mitigation are passed into each of these PromptInput objects respectively. 3. Added ground truth labels to the RiskAssessment objects in the examples_risk_assessment file for each of these get_prompt_input functions. 4. Added tests for each of these ground truth labels. 3 tests scored 100, 1 test scored 90. 5. Changed evaluation.py so that prompts are asked sequentially if and only if a wrong answer has not already been produced and the corresponding piece of feedback has not already been produced, e.g. won't ask mitigation prompt if mitigation_protective_equipment came back True.