### PR TITLE
Testing whether prevention and mitigation questions should be in separate prompts

### DIFF
--- a/app/PromptInputs.py
+++ b/app/PromptInputs.py
@@ -403,47 +403,203 @@ class Prevention(PromptInput):
         self.hazard = hazard
         self.how_it_harms = how_it_harms
         self.who_it_harms = who_it_harms
-    
-    def generate_prompt_without_few_shot_examples(self, hazard_event, harm_caused):
 
+    def generate_prompt_without_few_shot_examples(self):
         return f'''Follow these instructions:
-        1. In one sentence, describe the event that leads to harm: '{hazard_event}' during the
-        activity: '{self.activity}' given how the harm caused: '{harm_caused}' for {self.who_it_harms}.
-        2. Explain whether or not '{self.control_measure}' reduces the likelihood that '{hazard_event}' occurs.
+        1. In one sentence, describe the event that leads to harm: <hazard event> during the
+        activity: '{self.activity}' given the harm caused: <harm caused> for {self.who_it_harms}.
+        2. Thinking step by step, explain whether or not '{self.control_measure}' reduces the likelihood that <hazard event> occurs.
         If so, answer True'''
     
     def generate_prompt(self, hazard_event, harm_caused):
-        all_few_shot_examples = """
+        few_shot_examples = """
+        <EXAMPLE INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: "Water being spilt on the floor causing students to slip' during the
+        activity: 'Fluids laboratory' given the harm caused: 'Impact injuries' for Students.
+        2. Thinking step by step, explain whether or not 'Do not move the water tank when it is full' reduces the likelihood that the event: "Water being spilt on the floor causing students to slip' occurs.
+        If so, answer True
+        </EXAMPLE INSTRUCTIONS>
 
-        Example Outputs: 
-
-        Hazard Description: The hazard of 'Ink spillage on student's face' during the activity 'Fluids laboratory' can lead to serious eye damage to students.
-        Prevention Explanation: 'First aid' is a reactive measure applied after the hazard of 'Ink spillage on student's face'; it therefore does not reduce the likelihood of the hazard and is not a prevention measure.
-        Answer: False
-
+        <EXAMPLE OUTPUT>
         Hazard Description: The hazard of 'Water being spilt on the floor causing students to slip' during the activity 'Fluids laboratory' can lead to impact injuries.
         Prevention Explanation: 'Keeping the water tank stationary when it's full' means water cannot be spilled on to the floor by moving the water tank; no water on the floor reduces the likelihood of the student slipping; since it reduces the likelihood of the hazard, it is a prevention measure.
         Answer: True
+        </EXAMPLE OUTPUT>
 
+        <EXAMPLE INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: 'Cut Zip tie flies and hits audience member' during the
+        activity: 'Using a spring contraption as a demonstration for a TPS presentation' given the harm caused: 'Impact injuries' for Audience.   
+        2. Thinking step by step, explain whether or not 'Keep hand around zip tie when cutting to stop it from flying' reduces the likelihood that the event: 'Cut Zip tie flies and hits audience member' occurs.
+        If so, answer True
+        </EXAMPLE INSTRUCTIONS>
+
+        <EXAMPLE OUTPUT>
         Hazard Description: The hazard of 'Cut Zip tie flies and hits audience member' during the activity 'Using a spring contraption as a demonstration for a TPS presentation' can lead to impact injuries.
         Prevention Explanation: 'Keeping hand around zip tie when cutting to stop it from flying' will stop the zip tie from flying and therefore stop the hazard from occurring. Therefore, the likelihood of the hazard occurring has been reduced to zero; since the likelihood has been reduced, it is therefore a prevention measure.
         Answer: True
+        </EXAMPLE OUTPUT>
+
+        <EXAMPLE INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: 'Ink spillage on student's face' during the
+        activity: 'Fluids laboratory' given the harm caused: 'Series eye damage' for Students.
+        2. Thinking step by step, explain whether or not 'Wash your eyes with clean water' reduces the likelihood that the event: 'Ink spillage on student's face' occurs. 
+        If so, answer True
+        </EXAMPLE INSTRUCTIONS>
+
+        <EXAMPLE OUTPUT>
+        Hazard Description: The hazard of 'Ink spillage on student's face' during the activity 'Fluids laboratory' can lead to serious eye damage to students.
+        Prevention Explanation: 'First aid' is a reactive measure applied after the hazard of 'Ink spillage on student's face'; it therefore does not reduce the likelihood of the hazard and is not a prevention measure.
+        Answer: False
+        </EXAMPLE OUTPUT>
         """
-
         return f'''
-        {all_few_shot_examples}
 
-        {self.generate_prompt_without_few_shot_examples(hazard_event, harm_caused)}
+        <CONTEXT>
+        You are a Risk Assessment expert responsible for giving feedback on Risk Assessment inputs.
+        </CONTEXT>
 
+        <STYLE>
+        Follow the writing style of a secondary school teacher.
+        </STYLE>
+
+        <TONE>
+        Use a formal tone.
+        </TONE>
+
+        <AUDIENCE>
+        Your audience is a student who is learning how to write a risk assessment.
+        </AUDIENCE>
+
+        <EXAMPLES>
+        {few_shot_examples}
+        </EXAMPLES>
+
+        <INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: '{hazard_event}' during the
+        activity: '{self.activity}' given the harm caused: '{harm_caused}' for {self.who_it_harms}.
+        2. Thinking step by step, explain whether or not '{self.control_measure}' reduces the likelihood that '{hazard_event}' occurs.
+        If so, answer True
+        </INSTRUCTIONS>
+
+        <OUTPUT FORMAT>
         Use the following output format:
         Hazard Description: <your hazard description>
         Prevention Explanation: <your explanation>
-        Overall Answer: <your answer>'''
+        Overall Answer: <your answer>
+        </OUTPUT FORMAT>
+        
+        <OUTPUT>
+        Hazard Description: '''
+    
+class Mitigation(PromptInput):
+    def __init__(self, control_measure, activity, hazard, how_it_harms, who_it_harms):
+        super().__init__()
+        self.control_measure = control_measure
+        self.activity = activity
+        self.hazard = hazard
+        self.how_it_harms = how_it_harms
+        self.who_it_harms = who_it_harms
+
+    def generate_prompt_without_few_shot_examples(self):
+        return f'''Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: <hazard event> during the
+        activity: '{self.activity}' given the harm caused: <harm caused> for {self.who_it_harms}.
+        2. Thinking step by step, assuming the event: '{hazard_event}' has occurred, explain whether or not '{self.control_measure}' removes or reduces the harm caused by <harm caused> for the '{self.who_it_harms}'.
+        If so, answer True'''
+    
+    def generate_prompt(self, hazard_event, harm_caused):
+        few_shot_examples = """
+        <EXAMPLE INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: "Water being spilt on the floor causing students to slip' during the
+        activity: 'Fluids laboratory' given the harm caused: 'Impact injuries' for Students.
+        2. Thinking step by step, assuming the event: '{hazard_event}' has occurred, explain whether or not 'Do not move the water tank when it is full' removes or reduces the harm caused by 'Impact injuries' for the 'Students'.
+        If so, answer True
+        </EXAMPLE INSTRUCTIONS>
+
+        <EXAMPLE OUTPUT>
+        Hazard Description: The hazard of 'Ink spillage on student's face' during the activity 'Fluids laboratory' can lead to serious eye damage to students.
+        Mitigation Explanation: If water has been spilled on the floor, 'not moving the water tank when it is full' does not remove or reduce the harm caused by the hazard, as the water is already spilled to pose a slipping hazard; as it does not reduce the harm caused by the hazard, it is not a mitigation measure.
+        Answer: False
+        </EXAMPLE OUTPUT>
+
+        <EXAMPLE INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: 'Cut Zip tie flies and hits audience member' during the
+        activity: 'Using a spring contraption as a demonstration for a TPS presentation' given the harm caused: 'Impact injuries' for Audience.   
+        2. Thinking step by step, assuming the event: '{hazard_event}' has occurred, explain whether or not 'Keep hand around zip tie when cutting to stop it from flying' removes or reduces the harm caused by 'Impact injuries' for the 'Audience'.
+        If so, answer True
+        </EXAMPLE INSTRUCTIONS>
+
+        <EXAMPLE OUTPUT>
+        Hazard Description: The hazard of 'Cut Zip tie flies and hits audience member' during the activity 'Using a spring contraption as a demonstration for a TPS presentation' can lead to impact injuries.
+        Mitigation Explanation: If the hazard occurs and the zip tie flies and hits an audience member, 'keeping hand around zip tie when cutting to stop it from flying' does not remove or reduce the impact injury caused by the hazard, as the zip tie has already flown and caused harm; it is therefore not a mitigation measure.
+        Answer: False
+        </EXAMPLE OUTPUT>
+
+        <EXAMPLE INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: 'Ink spillage on student's face' during the
+        activity: 'Fluids laboratory' given the harm caused: 'Series eye damage' for Students.
+        2. Thinking step by step, assuming the event: '{hazard_event}' has occurred, explain whether or not 'Wash your eyes with clean water' removes or reduces the harm caused by 'Serious eye damage' for the 'Students'.
+        If so, answer True
+        </EXAMPLE INSTRUCTIONS>
+
+        <EXAMPLE OUTPUT>
+        Hazard Description: The hazard of 'Ink spillage on student's face' during the activity 'Fluids laboratory' can lead to serious eye damage to students.
+        Mitigation Explanation: If ink has been spilled onto a student's face, 'first aid' will help to wash the ink out of the eyes and reduce eye damage after the hazard has occurred; as it reduces the harm caused by the hazard, it is therefore a mitigation measure.
+        Answer: True
+        </EXAMPLE OUTPUT>
+        """
+
+        return f'''
+
+        <CONTEXT>
+        You are a Risk Assessment expert responsible for giving feedback on Risk Assessment inputs.
+        </CONTEXT>
+
+        <STYLE>
+        Follow the writing style of a secondary school teacher.
+        </STYLE>
+
+        <TONE>
+        Use a formal tone.
+        </TONE>
+
+        <AUDIENCE>
+        Your audience is a student who is learning how to write a risk assessment.
+        </AUDIENCE>
+
+        <EXAMPLES>
+        {few_shot_examples}
+        </EXAMPLES>
+
+        <INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: '{hazard_event}' during the
+        activity: '{self.activity}' given the harm caused: '{harm_caused}' for {self.who_it_harms}.
+        2. Thinking step by step, assuming the event: '{hazard_event}' has occurred, explain whether or not '{self.control_measure}' removes or reduces the harm caused by {harm_caused} for the '{self.who_it_harms}'.
+        If so, answer True
+        </INSTRUCTIONS>
+
+        <OUTPUT FORMAT>
+        Use the following output format:
+        Hazard Description: <your hazard description>
+        Mitigation Explanation: <your explanation>
+        Overall Answer: <your answer>
+        </OUTPUT FORMAT>
+        
+        <OUTPUT>
+        Hazard Description: '''
 
 class OldPrevention(PromptInput):
-    def __init__(self, prevention, activity, hazard, how_it_harms, who_it_harms):
+    def __init__(self, control_measure, activity, hazard, how_it_harms, who_it_harms):
         super().__init__()
-        self.prevention = prevention
+        self.control_measure = control_measure
         self.activity = activity
         self.hazard = hazard
         self.how_it_harms = how_it_harms
@@ -456,94 +612,134 @@ class OldPrevention(PromptInput):
     def get_field_checked(self):
         return 'Prevention'
     
-    def generate_prompt_without_few_shot_examples(self, hazard_event, harm_caused):
+    def generate_prompt_without_few_shot_examples(self):
 
         return f'''Follow these instructions:
-        1. In one sentence, describe the event that leads to harm: '{hazard_event}' during the
-        activity: '{self.activity}' given how the harm caused: '{harm_caused}' for {self.who_it_harms}.
-        2. Explain whether or not '{self.prevention}' reduces the likelihood that '{hazard_event}' occurs.
+        1. In one sentence, describe the event that leads to harm: <hazard event> during the
+        activity: '{self.activity}' given the harm caused: <harm caused> for {self.who_it_harms}.
+        2. Thinking step by step, explain whether or not '{self.control_measure}' reduces the likelihood that <hazard event> occurs.
         If so, it is a prevention measure.
-        3. If the hazard occurs, explain whether or not '{self.prevention}' removes or reduces the harm caused by '{harm_caused}' for the '{self.who_it_harms}'.
+        3. Thinking step by step, explain whether or not '{self.control_measure}' removes or reduces the harm caused by <harm caused> for the '{self.who_it_harms}'.
         If so, it is a mitigation measure.
-        4. If it is a prevention measure, answer 'Prevention'. If it is a migitation meausure, answer 'Mitigation'. 
-        If it is neither a prevention measure nor a mitigation measure, answer 'Neither'. If it is both a 
+        4. If it is a prevention measure, answer 'Prevention'. If it is a migitation meausure, answer 'Mitigation'.
+        If it is neither a prevention measure nor a mitigation measure, answer 'Neither'. If it is both a
         prevention measure and a mitigation measure, answer 'Both'.'''
     
     def generate_prompt(self, hazard_event, harm_caused):
 
         all_few_shot_examples = """
-        Input:
+        <EXAMPLE INSTRUCTIONS>
         Follow these instructions:
         1. In one sentence, describe the hazard: 'Ink spillage on students face' during the
         activity: 'Fluids laboratory' given how the hazard causes harm: 'Serious eye damage'.
-        3. Explain whether or not 'First aid' reduces the likelihood that the hazard occurs.
+        3. Thinking step by step, explain whether or not 'First aid' reduces the likelihood that the hazard occurs.
         If so, it is a prevention measure.
-        4. Assuming the hazard occurs, explain whether or not 'First aid' removes or reduces the chance of 'Serious eye damage'.
+        4. Thinking step by step, explain whether or not 'First aid' removes or reduces the chance of 'Serious eye damage'.
         If so, it is a mitigation measure.
         5. If it is a prevention measure, answer 'Prevention'. If it is a migitation meausure, answer 'Mitigation'.
         If it is neither a prevention measure nor a mitigation measure, answer 'Neither'. If it is both a        
         prevention measure and a mitigation measure, answer 'Both'.
+        </EXAMPLE INSTRUCTIONS>
 
-        Output: 
+        <EXAMPLE OUTPUT>
         Hazard Description: The hazard of 'Ink spillage on student's face' during the activity 'Fluids laboratory' can lead to serious eye damage to students.
         Prevention Explanation: 'First aid' is a reactive measure applied after the hazard of 'Ink spillage on student's face'; it therefore does not reduce the likelihood of the hazard and is not a prevention measure.
         Mitigation Explanation: If ink has been spilled onto a student's face, 'first aid' will help to wash the ink out of the eyes and reduce eye damage after the hazard has occurred; as it reduces the harm caused by the hazard, it is therefore a mitigation measure.
         Answer: Mitigation.
+        </EXAMPLE OUTPUT>
 
-        Follow these
-        Input: instructions:
+        <EXAMPLE INSTRUCTIONS>
+        Follow these instructions:
         1. In one sentence, describe the hazard: 'Water being spilt on the floor causing students to slip' during the
         activity: 'Fluids laboratory' given how the hazard harms: 'Impact injury'.
-        3. Explain whether or not 'Do not move the water tank when it is full' reduces the likelihood that the hazard occurs.
+        3. Thinking step by step, explain whether or not 'Do not move the water tank when it is full' reduces the likelihood that the hazard occurs.
         If so, it is a prevention measure.
-        4. Assuming the hazard occurs, explain whether or not 'Do not move the water tank when it is full' removes or reduces the chance of 'Impact injury'.
+        4. Thinking step by step, explain whether or not 'Do not move the water tank when it is full' removes or reduces the chance of 'Impact injury'.
         If so, it is a mitigation measure.
         5. If it is a prevention measure, answer 'Prevention'. If it is a migitation meausure, answer 'Mitigation'.
         If it is neither a prevention measure nor a mitigation measure, answer 'Neither'. If it is both a        
         prevention measure and a mitigation measure, answer 'Both'.
+        </EXAMPLE INSTRUCTIONS>
 
+        <EXAMPLE OUTPUT>
         Hazard Description: The hazard of 'Water being spilt on the floor causing students to slip' during the activity 'Fluids laboratory' can lead to impact injuries.
         Prevention Explanation: 'Keeping the water tank stationary when it's full' means water cannot be spilled on to the floor by moving the water tank; no water on the floor reduces the likelihood of the student slipping; since it reduces the likelihood of the hazard, it is a prevention measure.
         Mitigation Explanation: If water has been spilled on the floor, 'not moving the water tank when it is full' does not remove or reduce the harm caused by the hazard, as the water is already spilled to pose a slipping hazard; as it does not reduce the harm caused by the hazard, it is not a mitigation measure.
         Answer: Prevention.
+        </EXAMPLE OUTPUT>
 
+        <EXAMPLE INSTRUCTIONS>
         Follow these instructions:
         1. In one sentence, describe the hazard: 'Cut Zip tie flies and hits audience member' during the
         activity: 'Using a spring contraption as a demonstration for a TPS presentation' given how the hazard harms: 'Impact injury.'.
-        2. Explain whether or not 'Keep hand around zip tie when cutting to stop it from flying' reduces the likelihood that the hazard occurs.
+        3. Thinking step by step, explain whether or not 'Keep hand around zip tie when cutting to stop it from flying' reduces the likelihood that the hazard occurs.
         If so, it is a prevention measure.
-        3. If the hazard occurs, explain whether or not 'Keep hand around zip tie when cutting to stop it from flying' removes or reduces the chance of Impact injury..
+        3. Thinking step by step, explain whether or not 'Keep hand around zip tie when cutting to stop it from flying' removes or reduces the chance of Impact injury..
+        If so, it is a mitigation measure.
+        4. If it is a prevention measure, answer 'Prevention'. If it is a migitation meausure, answer 'Mitigation'.
+        If it is neither a prevention measure nor a mitigation measure, answer 'Neither'. If it is both a
+        prevention measure and a mitigation measure, answer 'Both'.
+        </EXAMPLE INSTRUCTIONS>
+
+        <EXAMPLE OUTPUT>
+        Hazard Description: The hazard of 'Cut Zip tie flies and hits audience member' during the activity 'Using a spring contraption as a demonstration for a TPS presentation' can lead to impact injuries.
+        Prevention Explanation: 'Keeping hand around zip tie when cutting to stop it from flying' will stop the zip tie from flying and therefore stop the hazard from occurring. Therefore, the likelihood of the hazard occurring has been reduced to zero; since the likelihood has been reduced, it is therefore a prevention measure.
+        Mitigation Explanation: If the hazard occurs and the zip tie flies and hits an audience member, 'keeping hand around zip tie when cutting to stop it from flying' does not remove or reduce the impact injury caused by the hazard, as the zip tie has already flown and caused harm; it is therefore not a mitigation measure.
+        Answer: Prevention.
+        </EXAMPLE OUTPUT>
+        """
+
+        return f'''
+        <CONTEXT>
+        You are a Risk Assessment expert responsible for giving feedback on Risk Assessment inputs.
+        </CONTEXT>
+
+        <STYLE>
+        Follow the writing style of a secondary school teacher.
+        </STYLE>
+
+        <TONE>
+        Use a formal tone.
+        </TONE>
+
+        <AUDIENCE>
+        Your audience is a student who is learning how to write a risk assessment.
+        </AUDIENCE>
+
+        {all_few_shot_examples}
+
+        <INSTRUCTIONS>
+        Follow these instructions:
+        1. In one sentence, describe the event that leads to harm: {hazard_event} during the
+        activity: '{self.activity}' given the harm caused: {harm_caused} for {self.who_it_harms}.
+        2. Thinking step by step, explain whether or not '{self.control_measure}' reduces the likelihood that {hazard_event} occurs.
+        If so, it is a prevention measure.
+        3. Thinking step by step, explain whether or not '{self.control_measure}' removes or reduces the harm caused by {harm_caused} for the '{self.who_it_harms}'.
         If so, it is a mitigation measure.
         4. If it is a prevention measure, answer 'Prevention'. If it is a migitation meausure, answer 'Mitigation'.
         If it is neither a prevention measure nor a mitigation measure, answer 'Neither'. If it is both a
         prevention measure and a mitigation measure, answer 'Both'.
 
-        Hazard Description: The hazard of 'Cut Zip tie flies and hits audience member' during the activity 'Using a spring contraption as a demonstration for a TPS presentation' can lead to impact injuries.
-        Prevention Explanation: 'Keeping hand around zip tie when cutting to stop it from flying' will stop the zip tie from flying and therefore stop the hazard from occurring. Therefore, the likelihood of the hazard occurring has been reduced to zero; since the likelihood has been reduced, it is therefore a prevention measure.
-        Mitigation Explanation: If the hazard occurs and the zip tie flies and hits an audience member, 'keeping hand around zip tie when cutting to stop it from flying' does not remove or reduce the impact injury caused by the hazard, as the zip tie has already flown and caused harm; it is therefore not a mitigation measure.
-        Answer: Prevention.
-        """
-
-        return f'''
-        {all_few_shot_examples}
-
-        {self.generate_prompt_without_few_shot_examples(hazard_event, harm_caused)}
-
+        <OUTPUT FORMAT>
         Use the following output format:
         Hazard Description: <your hazard description>
         Prevention Explanation: <your prevention explanation>
         Mitigation Explanation: <your mitigation explanation>
-        Answer: <your answer>'''
+        Answer: <your answer>
+        </OUTPUT FORMAT>
+        
+        <OUTPUT>
+        Hazard Description: '''
     
     def get_shortform_feedback(self, feedback_type):
         if feedback_type == 'positive':
-            return f"Correct! '{self.prevention}' is a prevention measure for the hazard: '{self.hazard}'"
+            return f"Correct! '{self.control_measure}' is a prevention measure for the hazard: '{self.hazard}'"
         if feedback_type == 'both':
-            return f"Feedback cannot be provided for the prevention: '{self.prevention}'"
+            return f"Feedback cannot be provided for the prevention: '{self.control_measure}'"
         if feedback_type == 'neither':
-            return f"Incorrect. '{self.prevention}' is not a prevention measure for the hazard: '{self.hazard}'."
+            return f"Incorrect. '{self.control_measure}' is not a prevention measure for the hazard: '{self.hazard}'."
         if feedback_type == 'misclassification':
-            return f"Incorrect. '{self.prevention}' is actually a mitigation measure for the hazard: '{self.hazard}'."
+            return f"Incorrect. '{self.control_measure}' is actually a mitigation measure for the hazard: '{self.hazard}'."
     
     def get_longform_feedback(self, prompt_output='', pattern_to_search_for='Prevention Explanation'):
         regex_pattern_matcher = RegexPatternMatcher()
@@ -560,7 +756,7 @@ class OldPrevention(PromptInput):
         if recommendation_type == 'misclassification':
             return f"""A mitigation measure reduces the harm caused by the hazard event either while the hazard event is occurring or after it has occurred. On the other hand, a prevention measure reduces the likelihood of the hazard event occurring in the first place. Please use the above definitions to ammend your prevention input."""
     
-class Mitigation(PromptInput):
+class OldMitigation(PromptInput):
     def __init__(self, mitigation, activity, hazard, how_it_harms, who_it_harms):
         super().__init__()
         self.mitigation = mitigation
@@ -588,7 +784,7 @@ class Mitigation(PromptInput):
         activity: '{self.activity}' given how the hazard harms: '{self.how_it_harms}'
         and who the hazard harms: '{self.who_it_harms}'.
         2. In one sentence, explain why {self.how_it_harms} is a way that this hazard can cause harm.
-        3. Explain whether or not '{self.mitigation}' reduces the likelihood that the hazard event occurs.
+        3. Thinking step by step, explain whether or not '{self.mitigation}' reduces the likelihood that the hazard event occurs.
         If so, it is a prevention measure.
         4. Assuming the hazard event occurs, explain whether or not '{self.mitigation}' removes or reduces the harm caused by the event.
         If so, it is a mitigation measure.

--- a/app/RiskAssessment.py
+++ b/app/RiskAssessment.py
@@ -161,13 +161,37 @@ class RiskAssessment:
             hazard=self.hazard,
             control_measure=self.mitigation)
     
-    def get_mitigation_input(self):
+    def get_mitigation_prompt_with_prevention_input(self):
         return Mitigation(
             activity=self.activity,
             who_it_harms=self.who_it_harms,
             how_it_harms=self.how_it_harms,
             hazard=self.hazard,
-            mitigation=self.mitigation)
+            control_measure=self.prevention)
+    
+    def get_mitigation_prompt_with_mitigation_input(self):
+        return Mitigation(
+            activity=self.activity,
+            who_it_harms=self.who_it_harms,
+            how_it_harms=self.how_it_harms,
+            hazard=self.hazard,
+            control_measure=self.mitigation)
+    
+    def get_control_measure_prompt_with_prevention_input(self):
+        return OldPrevention(
+            activity=self.activity,
+            who_it_harms=self.who_it_harms,
+            how_it_harms=self.how_it_harms,
+            hazard=self.hazard,
+            control_measure=self.prevention)
+
+    def get_control_measure_prompt_with_mitigation_input(self):
+        return OldPrevention(
+            activity=self.activity,
+            who_it_harms=self.who_it_harms,
+            how_it_harms=self.how_it_harms,
+            hazard=self.hazard,
+            control_measure=self.mitigation)
     
     def check_that_likelihood_and_severity_values_are_between_1_and_4(self, likelihood, severity):
         try:

--- a/app/TestModelAccuracy.py
+++ b/app/TestModelAccuracy.py
@@ -309,6 +309,24 @@ class TestModelAccuracyForCompletePreventionPromptPipeline(TestModelAccuracyForC
     def get_classes(self):
         return ['prevention', 'mitigation', 'neither', 'both']
     
+    def get_first_prompt_input(self):
+        first_RA = self.list_of_risk_assessment_and_expected_outputs[0].risk_assessment
+
+        first_harm_caused_prompt_input = first_RA.get_harm_caused_and_hazard_event_input()
+        first_harm_caused_prompt = first_harm_caused_prompt_input.generate_prompt()
+        harm_caused_and_hazard_event_prompt_output, harm_caused_and_hazard_event_pattern = first_RA.get_prompt_output_and_pattern_matched(first_harm_caused_prompt_input, self.LLM)
+
+        hazard_event = harm_caused_and_hazard_event_pattern.hazard_event
+        harm_caused = harm_caused_and_hazard_event_pattern.harm_caused
+
+        first_prevention_prompt_with_prevention_input = first_RA.get_prevention_prompt_with_prevention_input()
+        first_prevention_prompt_with_prevention_prompt = first_prevention_prompt_with_prevention_input.generate_prompt(hazard_event=hazard_event, harm_caused=harm_caused)
+
+        first_mitigation_prompt_with_prevention_input = first_RA.get_mitigation_prompt_with_prevention_input()
+        first_mitigation_prompt_with_prevention_prompt = first_mitigation_prompt_with_prevention_input.generate_prompt(hazard_event=hazard_event, harm_caused=harm_caused)
+
+        return f'''Harm Caused:\n{first_harm_caused_prompt}\n\nPrevention :\n{first_prevention_prompt_with_prevention_prompt}\n\nMitigation: {first_mitigation_prompt_with_prevention_prompt}'''
+    
     def get_expected_output_and_pattern_matched_and_prompt_output(self, i):
         RA = self.list_of_risk_assessment_and_expected_outputs[i].risk_assessment
         expected_output = self.list_of_risk_assessment_and_expected_outputs[i].expected_output
@@ -322,25 +340,69 @@ class TestModelAccuracyForCompletePreventionPromptPipeline(TestModelAccuracyForC
         prevention_prompt_with_prevention_input = RA.get_prevention_prompt_with_prevention_input()
         prevention_prompt_with_prevention_output, prevention_prompt_with_prevention_pattern = RA.get_prompt_output_and_pattern_matched(prevention_prompt_with_prevention_input, self.LLM, harm_caused=harm_caused, hazard_event=hazard_event)
 
-        prevention_prompt_with_mitigation_input = RA.get_prevention_prompt_with_mitigation_input()
-        prevention_prompt_with_mitigation_output, prevention_prompt_with_mitigation_pattern = RA.get_prompt_output_and_pattern_matched(prevention_prompt_with_mitigation_input, self.LLM, harm_caused=harm_caused, hazard_event=hazard_event)
+        mitigation_prompt_with_prevention_input = RA.get_mitigation_prompt_with_prevention_input()
+        mitigation_prompt_with_prevention_output, mitigation_prompt_with_prevention_pattern = RA.get_prompt_output_and_pattern_matched(mitigation_prompt_with_prevention_input, self.LLM, harm_caused=harm_caused, hazard_event=hazard_event)
 
-        prompt_output = f'''{harm_caused_and_hazard_event_prompt_output}\n\n{prevention_prompt_with_prevention_output}\n\n{prevention_prompt_with_mitigation_output}'''
-        if prevention_prompt_with_prevention_pattern == True and prevention_prompt_with_mitigation_pattern == True:
+        prompt_output = f'''{harm_caused_and_hazard_event_prompt_output}\n\n{prevention_prompt_with_prevention_output}\n\n{mitigation_prompt_with_prevention_output}'''
 
+        if prevention_prompt_with_prevention_pattern == True and mitigation_prompt_with_prevention_pattern == True:
             return expected_output, 'both', prompt_output
         
-        if prevention_prompt_with_prevention_pattern == True and prevention_prompt_with_mitigation_pattern == False:
-            
+        if prevention_prompt_with_prevention_pattern == True and mitigation_prompt_with_prevention_pattern == False:
             return expected_output, 'prevention', prompt_output
         
-        if prevention_prompt_with_prevention_pattern == False and prevention_prompt_with_mitigation_pattern == True:
-                
+        if prevention_prompt_with_prevention_pattern == False and mitigation_prompt_with_prevention_pattern == True:
             return expected_output, 'mitigation', prompt_output
         
-        if prevention_prompt_with_prevention_pattern == False and prevention_prompt_with_mitigation_pattern == False:
-
+        if prevention_prompt_with_prevention_pattern == False and mitigation_prompt_with_prevention_pattern == False:
             return expected_output, 'neither', prompt_output
+
+class ControlMeasurePromptWithPreventionInput(TestModelAccuracyForCombinationOfPrompts):
+    def __init__(self, 
+                    LLM: LLMCaller,
+                    list_of_risk_assessment_and_expected_outputs: list[InputAndExpectedOutputForCombinedPrompts],
+                    number_of_examples_in_each_domain: dict,
+                    sheet_name: str,
+                    examples_gathered_or_generated_message: str,
+                    candidate_labels: list):
+        
+        super().__init__(LLM, list_of_risk_assessment_and_expected_outputs, number_of_examples_in_each_domain, sheet_name, examples_gathered_or_generated_message, candidate_labels)
+
+    def get_classes(self):
+        return ['prevention', 'mitigation', 'neither', 'both']
+    
+    def get_first_prompt_input(self):
+        first_RA = self.list_of_risk_assessment_and_expected_outputs[0].risk_assessment
+
+        first_harm_caused_prompt_input = first_RA.get_harm_caused_and_hazard_event_input()
+        first_harm_caused_prompt = first_harm_caused_prompt_input.generate_prompt()
+        harm_caused_and_hazard_event_prompt_output, harm_caused_and_hazard_event_pattern = first_RA.get_prompt_output_and_pattern_matched(first_harm_caused_prompt_input, self.LLM)
+
+        hazard_event = harm_caused_and_hazard_event_pattern.hazard_event
+        harm_caused = harm_caused_and_hazard_event_pattern.harm_caused
+
+        control_measure_prompt_with_prevention_input = first_RA.get_control_measure_prompt_with_prevention_input()
+        control_measure_prompt_with_prevention_prompt = control_measure_prompt_with_prevention_input.generate_prompt(hazard_event=hazard_event, harm_caused=harm_caused)
+
+        return f'''Harm Caused:\n{first_harm_caused_prompt}\n\nPrevention:\n{control_measure_prompt_with_prevention_prompt}'''
+    
+    def get_expected_output_and_pattern_matched_and_prompt_output(self, i):
+        RA = self.list_of_risk_assessment_and_expected_outputs[i].risk_assessment
+
+        expected_output = self.list_of_risk_assessment_and_expected_outputs[i].expected_output
+
+        harm_caused_and_hazard_event_prompt_input = RA.get_harm_caused_and_hazard_event_input()
+        harm_caused_and_hazard_event_prompt_output, harm_caused_and_hazard_event_pattern = RA.get_prompt_output_and_pattern_matched(harm_caused_and_hazard_event_prompt_input, self.LLM)
+
+        hazard_event = harm_caused_and_hazard_event_pattern.hazard_event
+        harm_caused = harm_caused_and_hazard_event_pattern.harm_caused
+
+        control_measure_prompt_with_prevention_input = RA.get_control_measure_prompt_with_prevention_input()
+        control_measure_prompt_with_prevention_output, control_measure_prompt_with_prevention_pattern = RA.get_prompt_output_and_pattern_matched(control_measure_prompt_with_prevention_input, self.LLM, harm_caused=harm_caused, hazard_event=hazard_event)
+
+        prompt_output = f'''{harm_caused_and_hazard_event_prompt_output}\n\n{control_measure_prompt_with_prevention_output}'''
+
+        return expected_output, control_measure_prompt_with_prevention_pattern, prompt_output
 
 # TODO: Remove all this duplicate code. There should only be one test and you should be able to specify whether 
 # it is mitigation or prevention that you want to test

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -59,28 +59,28 @@ class TestEvaluationFunction(unittest.TestCase):
 
     #     self.assertEqual(result.get("is_correct"), False)
 
-    # def test_returns_is_correct_true(self):
-    #     response = [["Fluids laboratory"],
-    #                 ["Water being spilt on the floor"],
-    #                 ["Slipping on the water on the floor causing impact injuries"],
-    #                 ["Students"],
-    #                 ["4"],
-    #                 ["1"],
-    #                 ["4"],
-    #                 ["Do not move the water tank when it is full"],
-    #                 ["""If someone gets injured due to slipping, apply an ice pack to the injured area and 
-    #                 seek medical advice without delay."""],
-    #                 ["1"],
-    #                 ["1"], 
-    #                 ["1"]]
-    #     answer = None
-    #     params: Params = {"is_feedback_text": False, "is_risk_matrix": False, "is_risk_assessment": True}
+    def test_returns_is_correct_true(self):
+        response = [["Fluids laboratory"],
+                    ["Water being spilt on the floor"],
+                    ["Slipping on the water on the floor causing impact injuries"],
+                    ["Students"],
+                    ["4"],
+                    ["1"],
+                    ["4"],
+                    ["Do not move the water tank when it is full"],
+                    ["""If someone gets injured due to slipping, apply an ice pack to the injured area and 
+                    seek medical advice without delay."""],
+                    ["1"],
+                    ["1"], 
+                    ["1"]]
+        answer = None
+        params: Params = {"is_feedback_text": False, "is_risk_matrix": False, "is_risk_assessment": True}
 
-    #     result = evaluation_function(response, answer, params)
+        result = evaluation_function(response, answer, params)
 
-    #     print(result.get("feedback"))
+        print(result.get("feedback"))
 
-    #     self.assertEqual(result.get("is_correct"), True)
+        self.assertEqual(result.get("is_correct"), True)
 
     # def test_no_information_provided_in_mitigation_input(self):
     #     response = [["Fluids laboratory"],
@@ -162,7 +162,6 @@ class TestEvaluationFunction(unittest.TestCase):
         
         self.assertEqual(result.get("is_correct"), True)
 
-                
     def test_handles_empty_input(self):
         self.assertEqual(RA_empty_input.get_empty_fields(), ['Activity'])
         self.assertEqual(RA_hearing_damage.get_empty_fields(), [])

--- a/app/example_risk_assessments.py
+++ b/app/example_risk_assessments.py
@@ -328,7 +328,7 @@ RA_heavy_weight_falls_on_demonstrator = RiskAssessmentWithoutNumberInputs(
     mitigation_prompt_expected_output='prevention',
 )
 
-RA_zip_cut_hits_audience = RiskAssessmentWithoutNumberInputs(
+RA_zip_tie_hits_audience = RiskAssessmentWithoutNumberInputs(
     activity='Using a spring contraption as a demonstration for a TPS presentation',
     hazard='Cut Zip tie may fly',
     who_it_harms='Audience',
@@ -594,52 +594,52 @@ RA_market_risk = RiskAssessmentWithoutNumberInputs(
 
 example_risk_assessments_dict = {
     'Old Physical Risks': [
-        RA_syringe_needle, 
-        RA_syringe_needle_mitigation_prevention_switched, 
-        RA_trombone_impact, 
-        RA_hearing_damage, 
-        RA_ink_spill_in_eye, 
-        RA_wet_hands_electric_shock, 
-        RA_tripping_on_belongings, 
-        RA_water_tank,
-        RA_paper_plane_impact, 
-        RA_climbing_gear_on_feet, 
-        RA_sharp_drone_propeller_blade, 
-        RA_battery_causes_fire, 
-        RA_heavy_weight_falls_on_demonstrator, 
-        RA_zip_cut_hits_audience,
-        RA_pencil_lead_projectile,
-        RA_incorrect_prevention_and_mitigation, 
-        RA_hearing_damage_mitigation_prevention_switched,
-        RA_wet_hands_electric_shock_mitigation_prevention_switched, 
-        RA_water_tank_mitigation_prevention_switched,
-        RA_climbing_gear_on_feet_mitigation_prevention_switched,
-        RA_mucking_out_horse,
-        RA_slitter_machine
+        # RA_syringe_needle, 
+        # RA_syringe_needle_mitigation_prevention_switched, 
+        # RA_trombone_impact, 
+        # RA_hearing_damage, 
+        # RA_ink_spill_in_eye, 
+        # RA_wet_hands_electric_shock, 
+        # RA_tripping_on_belongings, 
+        # RA_water_tank,
+        # RA_paper_plane_impact, 
+        # RA_climbing_gear_on_feet, 
+        # RA_sharp_drone_propeller_blade, 
+        # RA_battery_causes_fire, 
+        # RA_heavy_weight_falls_on_demonstrator, 
+        # RA_zip_tie_hits_audience,
+        # RA_pencil_lead_projectile,
+        # RA_incorrect_prevention_and_mitigation, 
+        # RA_hearing_damage_mitigation_prevention_switched,
+        # RA_wet_hands_electric_shock_mitigation_prevention_switched, 
+        # RA_water_tank_mitigation_prevention_switched,
+        # RA_climbing_gear_on_feet_mitigation_prevention_switched,
+        # RA_mucking_out_horse,
+        # RA_slitter_machine
         ],
 
     'New Physical Risks': [
         RA_fire_alarm,
         RA_mop_up_spill,
         RA_syringe_with_cover,
-        RA_hot_water_in_cups,
-        RA_bigger_beaker,
-        RA_campfire,
-        RA_bouldering,
-        RA_hob_burn,
-        RA_crossing_road,
-        RA_cycling,
-        RA_ladder,
-        RA_cycling_high_viz,
-        RA_cycling_safer_routes
+        # RA_hot_water_in_cups,
+        # RA_bigger_beaker,
+        # RA_campfire,
+        # RA_bouldering,
+        # RA_hob_burn,
+        # RA_crossing_road,
+        # RA_cycling,
+        # RA_ladder,
+        # RA_cycling_high_viz,
+        # RA_cycling_safer_routes
         ],
     
     'Finance Risks': [
-        RA_credit_risk,
-        RA_interest_rate_risk,
-        RA_liquidity_risk,
-        RA_operational_risk,
-        RA_market_risk
+        # RA_credit_risk,
+        # RA_interest_rate_risk,
+        # RA_liquidity_risk,
+        # RA_operational_risk,
+        # RA_market_risk
     ]
 }
 

--- a/app/generate_few_shot_examples.py
+++ b/app/generate_few_shot_examples.py
@@ -1,11 +1,11 @@
-# Current how it harms examples:
-from example_risk_assessments import RA_4_with_incorrect_how_it_harms
+# # Current how it harms examples:
+# from example_risk_assessments import RA_4_with_incorrect_how_it_harms
 
 # Current prevention examples:
-from example_risk_assessments_copy import RA_7_water_tank, RA_2_hearing_damage, RA_8_syringe_needle, RA_zip_tie
+from example_risk_assessments import RA_ink_spill_in_eye, RA_water_tank, RA_zip_tie_hits_audience
 
-# Current mitigation examples:
-from example_risk_assessments import RA_6, RA_mucking_out_horse
+# # Current mitigation examples:
+# from example_risk_assessments import RA_6, RA_mucking_out_horse
 
 def get_prevention_prompt(risk_assessment, few_shot=False):
     prevention = risk_assessment.get_prevention_input()
@@ -13,9 +13,37 @@ def get_prevention_prompt(risk_assessment, few_shot=False):
         return prevention.generate_prompt()
     else:
         return prevention.generate_prompt_without_few_shot_examples()
+    
+def get_prevention_prompt_with_prevention_input(risk_assessment, few_shot=False):
+    prevention = risk_assessment.get_prevention_prompt_with_prevention_input()
+    if few_shot:
+        return prevention.generate_prompt()
+    else:
+        return prevention.generate_prompt_without_few_shot_examples()
+    
+def get_prevention_prompt_with_mitigation_input(risk_assessment, few_shot=False):
+    prevention = risk_assessment.get_prevention_prompt_with_mitigation_input()
+    if few_shot:
+        return prevention.generate_prompt()
+    else:
+        return prevention.generate_prompt_without_few_shot_examples()
 
 def get_mitigation_prompt(risk_assessment, few_shot=False):
     mitigation = risk_assessment.get_mitigation_input()
+    if few_shot:
+        return mitigation.generate_prompt()
+    else:
+        return mitigation.generate_prompt_without_few_shot_examples()
+    
+def get_mitigation_prompt_with_prevention_input(risk_assessment, few_shot=False):
+    mitigation = risk_assessment.get_mitigation_prompt_with_prevention_input()
+    if few_shot:
+        return mitigation.generate_prompt()
+    else:
+        return mitigation.generate_prompt_without_few_shot_examples()
+    
+def get_mitigation_prompt_with_mitigation_input(risk_assessment, few_shot=False):
+    mitigation = risk_assessment.get_mitigation_prompt_with_mitigation_input()
     if few_shot:
         return mitigation.generate_prompt()
     else:
@@ -34,15 +62,16 @@ if __name__ == "__main__":
     # print(get_how_it_harms_prompt(RA_4_with_incorrect_how_it_harms)) # Incorrect example
 
     # # Prevention
-    # print(f'{get_mitigation_prompt(RA_4_with_first_aid)}\n\n\n') # correct = mitigation
-    # print(f'{get_prevention_prompt(RA_7_water_tank)}\n\n\n') # correct=prevention
-    # print(f'{get_mitigation_prompt(RA_2_hearing_damage)}\n\n\n') # correct=mitigation
-    # print(f'{get_mitigation_prompt(RA_8_syringe_needle)}\n\n\n') # correct=mitigation
-    # print(f'{get_mitigation_prompt(RA_3_water_from_instrument)}\n\n\n') # correct=prevention
-    print(f'{get_prevention_prompt(RA_zip_tie)}\n\n\n') # correct=prevention
+    # print(f'{get_prevention_prompt_with_prevention_input(RA_water_tank)}\n\n\n') # correct=prevention
+    # print(f'{get_prevention_prompt_with_prevention_input(RA_zip_tie_hits_audience)}\n\n\n') # correct=prevention
+    # print(f'{get_prevention_prompt_with_mitigation_input(RA_ink_spill_in_eye)}\n\n\n') # correct=prevention
     
     # # Mitigation
     # print(get_mitigation_prompt(RA_4_with_first_aid)) # Example where mitigation reduces the harm after hazard event occurred
     # print(get_mitigation_prompt(RA_mucking_out_horse)) # Example of mitigation which reduces the harm when the hazard event is occurring.
     # print(get_mitigation_prompt(RA_6)) # Example of prevention which got classified as a mitigation
     # print(get_how_it_harms_prompt(RA_mucking_out_horse, few_shot=True))
+
+    print(f'{get_mitigation_prompt_with_prevention_input(RA_water_tank)}\n\n\n') # correct=prevention
+    print(f'{get_mitigation_prompt_with_prevention_input(RA_zip_tie_hits_audience)}\n\n\n') # correct=prevention
+    print(f'{get_mitigation_prompt_with_mitigation_input(RA_ink_spill_in_eye)}\n\n\n') # correct=prevention

--- a/app/test_prevention_combined_prompts.py
+++ b/app/test_prevention_combined_prompts.py
@@ -1,4 +1,4 @@
-from TestModelAccuracy import TestModelAccuracyForCompletePreventionPromptPipeline
+from TestModelAccuracy import TestModelAccuracyForCompletePreventionPromptPipeline, ControlMeasurePromptWithPreventionInput
 from LLMCaller import OpenAILLM
 from example_risk_assessments import example_risk_assessments_dict, example_risk_assessments, number_of_risk_assessments_in_each_domain
 
@@ -18,5 +18,13 @@ if __name__ == '__main__':
                                     examples_gathered_or_generated_message='Risk assessments gathered and not AI-generated',
                                     candidate_labels=['prevention', 'mitigation', 'neither', 'both'],
                                     sheet_name='Combined Prevention Prompts')
-    
+
+    # test_accuracy = ControlMeasurePromptWithPreventionInput(
+    #                                   LLM=OpenAILLM(),                      
+    #                                 list_of_risk_assessment_and_expected_outputs=examples,
+    #                                 number_of_examples_in_each_domain=number_of_risk_assessments_in_each_domain,
+    #                                 examples_gathered_or_generated_message='Risk assessments gathered and not AI-generated',
+    #                                 candidate_labels=['prevention', 'mitigation', 'neither', 'both'],
+    #                                 sheet_name='Combined Prevention Prompts')
+
     test_accuracy.run_test()


### PR DESCRIPTION
1. Ran a test to see whether the accuracy of the prevention input classification for gpt-3.5 is improved when the prevention and mitigation questions are split into separate prompts. It was found that this reduces accuracy significantly. This is because asking the prevention/mitigation questions in the same prompt means the LLM has all available information about preventions and mitigations, meaning it is more informed and can classify between a prevention and mitigation. However, when the prevention/mitigation questions are asked in separate prompts, each prompt only has information about preventions or mitigations respectively meaning the True/False decision is not informed by information about the other type of control measure. 2. Updated evaluation.py to use the prompt which combines the prevention and mitigation questions. It passes evaluation_tests.py